### PR TITLE
Upgrade to Crystal 0.9

### DIFF
--- a/src/mock.cr
+++ b/src/mock.cr
@@ -25,10 +25,10 @@ def double(*args)
   Mock::Double.new(*args)
 end
 
-def it(description, file = __FILE__, line = __LINE__)
-  Mock.reset
-  previous_def(description, file, line) do
-    yield
+module Spec::DSL
+  def it(description, file = __FILE__, line = __LINE__)
+    Mock.reset
+    previous_def
     Mock.registry.each &.check_expectations
   end
 end

--- a/src/mock.cr
+++ b/src/mock.cr
@@ -21,11 +21,11 @@ module Mock
   end
 end
 
-def double(*args)
-  Mock::Double.new(*args)
-end
-
 module Spec::DSL
+  def double(*args)
+    Mock::Double.new(*args)
+  end
+
   def it(description, file = __FILE__, line = __LINE__)
     Mock.reset
     previous_def


### PR DESCRIPTION
The `#it` method lives now under `Spec::DSL`; I also moved `#double` under there as not to pollute the global space.

Note: There is one test failure, but I’m not yet sure whether it’s related to this fix:

```
  1) Mock asserting method calls is sensitive to arguments (trickier example)
     Failure/Error: @calls.should_not HaveCalledExpectation.new(expectation)

       expected a_method_with_arguments to not be called with arguments ["bye"], but was

     # ./src/mock/double.cr:41
```
